### PR TITLE
Remove latex release requirement to improve compatibility

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,4 @@
 \documentclass[12pt,a4paper]{scrreport}
-\RequirePackage[2023/11/01]{latexrelease}
 % Packages
 % \usepackage[english]{babel}  
 \usepackage[T1]{fontenc}    


### PR DESCRIPTION
## Summary
- Remove strict `latexrelease` requirement from `main.tex` so the document can compile on older TeX installations.

## Testing
- `latexmk main.tex` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b09a141384832a8b208a890345e07b